### PR TITLE
Add Customers, Employees, Orders tables

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,7 +1,17 @@
 import React from 'react';
 
-const Header: React.FC = () => {
-  return <div>Header</div>;
+interface HeaderProps {
+  category?: string;
+  title?: string;
+}
+
+const Header = ({ category, title }: HeaderProps) => {
+  return (
+    <div className="mb-10">
+      <p className="text-gray-400">{category}</p>
+      <p className="text-3xl font-extrabold tracking-light text-slate-900">{title}</p>
+    </div>
+  );
 };
 
 export default Header;

--- a/src/pages/Customers.tsx
+++ b/src/pages/Customers.tsx
@@ -1,7 +1,41 @@
 import React from 'react';
+import {
+  GridComponent,
+  ColumnsDirective,
+  ColumnDirective,
+  Page,
+  Selection,
+  Inject,
+  Edit,
+  Toolbar,
+  Sort,
+  Filter,
+} from '@syncfusion/ej2-react-grids';
+
+import { customersData, customersGrid } from '../data/dummy';
+import { Header } from '../components';
 
 const Customers: React.FC = () => {
-  return <div>Customers</div>;
+  return (
+    <div className="m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl">
+      <Header category="Page" title="Customers" />
+      <GridComponent
+        dataSource={customersData}
+        allowPaging={true}
+        allowSorting={true}
+        toolbar={['Delete']}
+        editSettings={{ allowDeleting: true, allowEditing: true }}
+        width="auto"
+      >
+        <ColumnsDirective>
+          {customersGrid.map((item, index) => (
+            <ColumnDirective key={index} {...item}></ColumnDirective>
+          ))}
+        </ColumnsDirective>
+        <Inject services={[Page, Toolbar, Selection, Edit, Sort, Filter]} />
+      </GridComponent>
+    </div>
+  );
 };
 
 export default Customers;

--- a/src/pages/Employees.tsx
+++ b/src/pages/Employees.tsx
@@ -1,7 +1,37 @@
 import React from 'react';
+import {
+  GridComponent,
+  ColumnsDirective,
+  ColumnDirective,
+  Page,
+  Search,
+  Inject,
+  Toolbar,
+} from '@syncfusion/ej2-react-grids';
+
+import { employeesData, employeesGrid } from '../data/dummy';
+import { Header } from '../components';
 
 const Employees: React.FC = () => {
-  return <div>Employees</div>;
+  return (
+    <div className="m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl">
+      <Header category="Page" title="Employees" />
+      <GridComponent
+        dataSource={employeesData}
+        allowPaging={true}
+        allowSorting={true}
+        toolbar={['Search']}
+        width="auto"
+      >
+        <ColumnsDirective>
+          {employeesGrid.map((item, index) => (
+            <ColumnDirective key={index} {...item}></ColumnDirective>
+          ))}
+        </ColumnsDirective>
+        <Inject services={[Page, Search, Toolbar]} />
+      </GridComponent>
+    </div>
+  );
 };
 
 export default Employees;

--- a/src/pages/Orders.tsx
+++ b/src/pages/Orders.tsx
@@ -1,7 +1,52 @@
 import React from 'react';
+import {
+  GridComponent,
+  ColumnsDirective,
+  ColumnDirective,
+  Resize,
+  Sort,
+  ContextMenu,
+  Filter,
+  Page,
+  ExcelExport,
+  PdfExport,
+  Edit,
+  Inject,
+} from '@syncfusion/ej2-react-grids';
+
+import { ordersData, contextMenuItems, ordersGrid } from '../data/dummy';
+import { Header } from '../components';
 
 const Orders: React.FC = () => {
-  return <div>Orders</div>;
+  return (
+    <div className="m-2 md:m-10 p-2 md:p-10 bg-white rounded-3xl">
+      <Header category="Page" title="Orders" />
+      <GridComponent
+        id="gridcomp"
+        dataSource={ordersData}
+        allowPaging={true}
+        allowSorting={true}
+      >
+        <ColumnsDirective>
+          {ordersGrid.map((item, index) => (
+            <ColumnDirective key={index} {...item}></ColumnDirective>
+          ))}
+        </ColumnsDirective>
+        <Inject
+          services={[
+            Resize,
+            Sort,
+            ContextMenu,
+            Filter,
+            Page,
+            ExcelExport,
+            Edit,
+            PdfExport,
+          ]}
+        />
+      </GridComponent>
+    </div>
+  );
 };
 
 export default Orders;


### PR DESCRIPTION
## What
- [x] Add Orders Table data
- [x] Add Employees Table data
- [x] Add Customers Table data

## Why
- Help manages the Orders, Employees, Customers Data

## How
- Using @syncfusion/ej2-react-grids
- Add code to src/pages/Orders.tsx
- Add code to src/pages/Employees.tsx
- Add code to src/pages/Customers.tsx

## How to QA
- Proof
<img width="1496" alt="image" src="https://user-images.githubusercontent.com/82252265/177691266-3e288c5e-45ae-48ee-aa14-fc44630f9fa6.png">
<img width="1483" alt="image" src="https://user-images.githubusercontent.com/82252265/177691288-2535b958-4c67-450f-9e61-f0a9a32c4d59.png">
<img width="1494" alt="image" src="https://user-images.githubusercontent.com/82252265/177691326-542bb06a-50dd-4d80-a7de-f5063189f67e.png">
