### PR TITLE
Add Line + Area Chart pages

### DIFF
--- a/src/components/Charts/LineChart.tsx
+++ b/src/components/Charts/LineChart.tsx
@@ -1,7 +1,47 @@
 import React from 'react';
+import {
+  ChartComponent,
+  SeriesCollectionDirective,
+  SeriesDirective,
+  Inject,
+  DateTime,
+  Legend,
+  Tooltip,
+  LineSeries,
+  AxisModel,
+} from '@syncfusion/ej2-react-charts';
+import {
+  StateContextType,
+  useStateContext,
+} from '../../contexts/ContextProvider';
+
+import {
+  lineCustomSeries,
+  LinePrimaryYAxis,
+  LinePrimaryXAxis,
+} from '../../data/dummy';
 
 const LineChart: React.FC = () => {
-  return <div>LineChart</div>;
+  const { currentMode } = useStateContext() as StateContextType;
+
+  return (
+    <ChartComponent
+      id="line-chart"
+      height="420px"
+      primaryXAxis={LinePrimaryXAxis as AxisModel}
+      primaryYAxis={LinePrimaryYAxis as AxisModel}
+      chartArea={{ border: { width: 0 } }}
+      tooltip={{ enable: true }}
+      background={currentMode === 'Dark' ? '#33373E' : '#FFF'}
+    >
+      <Inject services={[LineSeries, DateTime, Legend, Tooltip]} />
+      <SeriesCollectionDirective>
+        {lineCustomSeries.map((item, index) => (
+          <SeriesDirective key={index} {...item} />
+        ))}
+      </SeriesCollectionDirective>
+    </ChartComponent>
+  );
 };
 
 export default LineChart;

--- a/src/pages/Charts/Area.tsx
+++ b/src/pages/Charts/Area.tsx
@@ -1,7 +1,50 @@
 import React from 'react';
+import {
+  ChartComponent,
+  SeriesCollectionDirective,
+  SeriesDirective,
+  Inject,
+  DateTime,
+  Legend,
+  SplineAreaSeries,
+  AxisModel,
+} from '@syncfusion/ej2-react-charts';
+import { Header } from '../../components';
+import {
+  StateContextType,
+  useStateContext,
+} from '../../contexts/ContextProvider';
+
+import {
+  areaCustomSeries,
+  areaPrimaryYAxis,
+  areaPrimaryXAxis,
+} from '../../data/dummy';
 
 const Area: React.FC = () => {
-  return <div>Area</div>;
+  const { currentMode } = useStateContext() as StateContextType;
+
+  return (
+    <div className="m-4 md:m-10 mt-24 p-10 bg-white dark:bg-secondary-dark-bg rounded-3xl">
+      <Header category='Area' title="Inflation Rate in Percentage" />
+    <ChartComponent
+      id="area-chart"
+      height="420px"
+      primaryXAxis={areaPrimaryXAxis as AxisModel}
+      primaryYAxis={areaPrimaryYAxis as AxisModel}
+      chartArea={{ border: { width: 0 } }}
+      tooltip={{ enable: true }}
+      background={currentMode === 'Dark' ? '#33373E' : '#FFF'}
+    >
+      <Inject services={[SplineAreaSeries, DateTime, Legend]} />
+      <SeriesCollectionDirective>
+        {areaCustomSeries.map((item, index) => (
+          <SeriesDirective key={index} {...item} />
+        ))}
+      </SeriesCollectionDirective>
+    </ChartComponent>
+    </div>
+  );
 };
 
 export default Area;

--- a/src/pages/Charts/Line.tsx
+++ b/src/pages/Charts/Line.tsx
@@ -1,9 +1,15 @@
-import React from 'react'
+import React from 'react';
+import { Header, LineChart } from '../../components';
 
 const Line: React.FC = () => {
   return (
-    <div>Line</div>
-  )
-}
+    <div className="m-4 md:m-10 mt-24 p-10 bg-white dark:bg-secondary-dark-bg rounded-3xl">
+      <Header category="Chart" title="Inflation Rate" />
+      <div className="w-full">
+        <LineChart />
+      </div>
+    </div>
+  );
+};
 
-export default Line
+export default Line;


### PR DESCRIPTION
## What
- [x] Add Line Chart page
- [x] Add Area Chart page

## Why
- Helps user to analyze data more efficiently

## How
- Using @syncfusion/ej2-react-charts
- Add code to src/pages/Charts/Line.tsx
- Add code to src/pages/Charts/Area.tsx

## How to QA
- Proof
<img width="1503" alt="image" src="https://user-images.githubusercontent.com/82252265/177902415-c817d41e-9868-437f-81a0-1bf6c9abd49a.png">
<img width="1500" alt="image" src="https://user-images.githubusercontent.com/82252265/177902434-05b8e3bd-5efa-4390-8385-4c517a6e8dc3.png">
